### PR TITLE
Adding the Java code formatter as a maven plugin of Prettier-Java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: java
 jdk: oraclejdk11
 
 script:
-- ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+- ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/Application/easyapply/pom.xml
+++ b/Application/easyapply/pom.xml
@@ -82,6 +82,12 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<groupId>com.cosium.code</groupId>
+			</plugin>
+			<plugin>
+				<groupId>com.cosium.code</groupId>
+				<artifactId>maven-git-code-format</artifactId>
+				<version>1.39</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/Application/easyapply/pom.xml
+++ b/Application/easyapply/pom.xml
@@ -82,7 +82,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<groupId>com.cosium.code</groupId>
 			</plugin>
 			<plugin>
 				<groupId>com.hubspot.maven.plugins</groupId>

--- a/Application/easyapply/pom.xml
+++ b/Application/easyapply/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<java.version>11</java.version>
+		<plugin.prettier.goal>write</plugin.prettier.goal>
 	</properties>
 
 	<dependencies>

--- a/Application/easyapply/pom.xml
+++ b/Application/easyapply/pom.xml
@@ -85,9 +85,20 @@
 				<groupId>com.cosium.code</groupId>
 			</plugin>
 			<plugin>
-   				<groupId>com.cosium.code</groupId>
-  			        <artifactId>maven-git-code-format</artifactId>
-   				<version>1.39</version>
+				<groupId>com.cosium.code</groupId>
+				<artifactId>git-code-format-maven-plugin</artifactId>
+				<version>${git-code-format-maven-plugin.version}</version>
+				<executions>
+					<!-- ... -->
+				</executions>
+				<configuration>
+					<googleJavaFormatOptions>
+						<aosp>false</aosp>
+						<fixImportsOnly>false</fixImportsOnly>
+						<skipSortingImports>false</skipSortingImports>
+						<skipRemovingUnusedImports>false</skipRemovingUnusedImports>
+					</googleJavaFormatOptions>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/Application/easyapply/pom.xml
+++ b/Application/easyapply/pom.xml
@@ -85,20 +85,10 @@
 				<groupId>com.cosium.code</groupId>
 			</plugin>
 			<plugin>
-				<groupId>com.cosium.code</groupId>
-				<artifactId>git-code-format-maven-plugin</artifactId>
-				<version>${git-code-format-maven-plugin.version}</version>
-				<executions>
-					<!-- ... -->
-				</executions>
-				<configuration>
-					<googleJavaFormatOptions>
-						<aosp>false</aosp>
-						<fixImportsOnly>false</fixImportsOnly>
-						<skipSortingImports>false</skipSortingImports>
-						<skipRemovingUnusedImports>false</skipRemovingUnusedImports>
-					</googleJavaFormatOptions>
-				</configuration>
+				<groupId>com.hubspot.maven.plugins</groupId>
+				<artifactId>prettier-maven-plugin</artifactId>
+				<!-- Find the latest version at https://github.com/jhipster/prettier-java/releases -->
+				<version>0.8</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/Application/easyapply/pom.xml
+++ b/Application/easyapply/pom.xml
@@ -87,8 +87,22 @@
 			<plugin>
 				<groupId>com.hubspot.maven.plugins</groupId>
 				<artifactId>prettier-maven-plugin</artifactId>
-				<!-- Find the latest version at https://github.com/jhipster/prettier-java/releases -->
 				<version>0.8</version>
+				<configuration>
+					<printWidth>90</printWidth>
+					<tabWidth>2</tabWidth>
+					<useTabs>false</useTabs>
+					<ignoreConfigFile>true</ignoreConfigFile>
+					<ignoreEditorConfig>true</ignoreEditorConfig>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>${plugin.prettier.goal}</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/Application/easyapply/pom.xml
+++ b/Application/easyapply/pom.xml
@@ -85,9 +85,9 @@
 				<groupId>com.cosium.code</groupId>
 			</plugin>
 			<plugin>
-				<groupId>com.cosium.code</groupId>
-				<artifactId>maven-git-code-format</artifactId>
-				<version>1.39</version>
+   				<groupId>com.cosium.code</groupId>
+  			        <artifactId>maven-git-code-format</artifactId>
+   				<version>1.39</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
A maven plugin that automatically deploys https://github.com/google/google-java-format code formatter as a pre-commit git hook Taken from - https://javalibs.com/plugin/com.cosium.code/maven-git-code-format